### PR TITLE
Use gemini-cli package

### DIFF
--- a/common/packages.nix
+++ b/common/packages.nix
@@ -4,7 +4,7 @@
     # TUI
     helix gitui ranger gdu bottom
     # CLI
-    neofetch bat eza rm-improved duf xcp less codex gh
+    neofetch bat eza rm-improved duf xcp less codex gemini-cli gh
     # network
     curl wget openssh
   ];


### PR DESCRIPTION
## Summary
- replace the invalid `gemini` package entry with the correct `gemini-cli` package in shared packages

## Testing
- nix --extra-experimental-features 'nix-command flakes' flake check --no-write-lock-file

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a874098cc832fa5edd2e878937c63)